### PR TITLE
Enhance visuals with icons and table styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ NautilusTrader is a rapidly evolving open-source platform for algorithmic tradin
 * ✅ **No frontend code**: work entirely in Python, no harder than Jupyter Notebook.
 * ✅ **Great for presentations**: beautiful and clear visualizations for investors and team members.
 * ✅ **Time-saving**: quickly identify bugs and strategy issues.
+* ✅ **Improved visuals**: themed widgets, icons and styled data tables.
 
 ---
 


### PR DESCRIPTION
## Summary
- style data frames with compact padding
- add trade log styling for profit column
- provide icons for KPI metrics
- allow selecting dark or light theme
- style metrics table
- document improved visuals in README

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849729db0b0832bbe9f2aa699408c24