### PR TITLE
Add ClickHouse data source option

### DIFF
--- a/modules/backtest_runner.py
+++ b/modules/backtest_runner.py
@@ -304,11 +304,18 @@ def run_backtest(
     strat_cls: Type[Strategy],
     cfg_cls: Type[StrategyConfig],
     params: Dict[str, Any],
-    data_file: str,
-    actor_cls: Type, # <-- ИЗМЕНЕНИЕ: Добавлен параметр actor_cls
+    data: Any,
+    actor_cls: Type,  # <-- ИЗМЕНЕНИЕ: Добавлен параметр actor_cls
     reuse_engine: Optional[BacktestEngine] = None,
 ) -> Dict[str, Any]:
-    csv = load_ohlcv_csv(data_file)
+    """Run a back-test using either a CSV path or a ready DataFrame."""
+
+    if isinstance(data, str):
+        csv = load_ohlcv_csv(data)
+    elif isinstance(data, pd.DataFrame):
+        csv = data
+    else:
+        raise TypeError("data must be a path to CSV or pandas.DataFrame")
     instr, bar_type, bars, price_df = dataframe_to_bars(csv)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pandas
 numpy
 plotly
 nautilus_trader
+clickhouse-driver


### PR DESCRIPTION
## Summary
- support running backtests from ClickHouse or CSV
- update sidebar to pick data source with tabs
- fetch candles from ClickHouse when selected
- allow `run_backtest` to accept DataFrame input
- add `clickhouse-driver` to requirements
- load CSV data via `load_ohlcv_csv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d8f938660832bb30e029a05dabe38