### PR TITLE
Add data source header

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -50,8 +50,7 @@ st.markdown(
     .stDataFrame tbody tr td { padding-top:2px; padding-bottom:2px; }
     /* tighter spacing for sidebar data source section */
     [data-testid="stSidebar"] .data-source-header {
-        margin-top:-0.5rem;
-        margin-bottom:0;
+        margin-bottom:-2.2rem;
     }
     [data-testid="stSidebar"] [data-testid="stTabs"] {
         margin-top:0;
@@ -697,7 +696,7 @@ with st.sidebar:
 
     # ── Data source tabs ────────────────────────────────────────────────
     st.markdown(
-        "<h5 class='data-source-header'>Data source</h5>",
+        "<h3 class='data-source-header'>Data source</h3>",
         unsafe_allow_html=True,
     )
     csv_path = None


### PR DESCRIPTION
## Summary
- make the data source section clearer in the sidebar with a header

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685e663b232c833398c12b1d50f4ce64