### PR TITLE
Fix dashboard layout

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -891,4 +891,4 @@ with st.sidebar:
                 )
         log_text = log_stream.getvalue()
 
-    draw_dashboard(result, log_text, TPL, ACCENT, NEG)
+draw_dashboard(result, log_text, TPL, ACCENT, NEG)


### PR DESCRIPTION
## Summary
- fix indentation so main dashboard renders outside of sidebar

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6867ca7ab52c832b9940bfb059f98016