### PR TITLE
Add overview section and improve layout

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -347,6 +347,13 @@ def draw_dashboard(
         "Win Rate": "Share of profitable trades",
     }
 
+    _fmt_pct = lambda v: (
+        "—" if v is None or (isinstance(v, float) and np.isnan(v)) else f"{v:+.2%}"
+    )
+    _fmt_num = lambda v, p=2: (
+        "—" if v is None or (isinstance(v, float) and np.isnan(v)) else f"{v:,.{p}f}"
+    )
+
     extra_stats = parse_extra_stats(log_text)
 
     # ╭──────────────────── 📄  RUN METADATA (collapsed) ──────────────────────╮
@@ -406,13 +413,6 @@ def draw_dashboard(
             col.metric(f"{icon} {key}", text, help=tip)
 
     # ╭──────────────────── 💹 ACCOUNT & Performance ────────────────────────────╮
-
-    _fmt_pct = lambda v: (
-        "—" if v is None or (isinstance(v, float) and np.isnan(v)) else f"{v:+.2%}"
-    )
-    _fmt_num = lambda v, p=2: (
-        "—" if v is None or (isinstance(v, float) and np.isnan(v)) else f"{v:,.{p}f}"
-    )
 
     with st.container(border=True):
         st.subheader("💹 Account & Performance")

--- a/app/main.py
+++ b/app/main.py
@@ -347,6 +347,14 @@ def draw_dashboard(
         "Win Rate": "Share of profitable trades",
     }
 
+    KPI_PCT_LABELS = {
+        "PnL (%)",
+        "Win Rate",
+        "Max DD (%)",
+        "Annual Return",
+        "Time in Market",
+    }
+
     _fmt_pct = lambda v: (
         "—" if v is None or (isinstance(v, float) and np.isnan(v)) else f"{v:+.2%}"
     )
@@ -413,48 +421,14 @@ def draw_dashboard(
             hdr[2].metric("Elapsed", run_meta["Elapsed time"])
             hdr[3].metric("Orders", run_meta["Total orders"])
 
-            overview_keys = [
-                "PnL ($)",
-                "PnL (%)",
-                "Annual Return",
-                "Max DD (%)",
-                "Max DD (days)",
-                "Win Rate",
-                "Sharpe",
-                "Sortino",
-                "Profit Factor",
-            ]
-            ocols = st.columns(len(overview_keys))
-            pct_labels = {
-                "PnL (%)",
-                "Win Rate",
-                "Max DD (%)",
-                "Annual Return",
-                "Time in Market",
-            }
-            for key, col in zip(overview_keys, ocols):
-                val = kpi.get(key)
-                icon = KPI_ICONS.get(key, "")
-                tip = KPI_TOOLTIPS.get(key, "")
-                is_pct = key in pct_labels
-                precision = 0 if key == "Max DD (days)" else 2
-                text = _fmt_pct(val) if is_pct else _fmt_num(val, precision)
-                col.metric(f"{icon} {key}", text, help=tip)
-
-            # KPI grid
             kcols = st.columns(len(kpi))
-            summary_pct_labels = {
-                "PnL (%)",
-                "Win Rate",
-                "Max DD (%)",
-                "Annual Return",
-                "Time in Market",
-            }
             for (label, value), col in zip(kpi.items(), kcols):
                 icon = KPI_ICONS.get(label, "")
-                is_pct = label in summary_pct_labels
-                text = _fmt_pct(value) if is_pct else _fmt_num(value)
-                col.metric(f"{icon} {label}", text)
+                tip = KPI_TOOLTIPS.get(label, "")
+                is_pct = label in KPI_PCT_LABELS
+                precision = 0 if label == "Max DD (days)" else 2
+                text = _fmt_pct(value) if is_pct else _fmt_num(value, precision)
+                col.metric(f"{icon} {label}", text, help=tip)
 
         # === Tab 1: Balances & Fees ==============================================
         with perf_tabs[1]:

--- a/app/main.py
+++ b/app/main.py
@@ -452,7 +452,7 @@ def draw_dashboard(
             tim = kpi.get("Time in Market")
             if tim is not None and not (isinstance(tim, float) and np.isnan(tim)):
                 st.write("Time in Market")
-                st.progress(float(tim))
+                st.progress(float(tim) / 100)
         # === Tab 1: Balances & Fees ==============================================
         with perf_tabs[1]:
             bal_cols = st.columns(4)

--- a/app/main.py
+++ b/app/main.py
@@ -409,6 +409,7 @@ def draw_dashboard(
                 "PnL",
                 "Return & Risk",
                 "General",
+                "Time in Market",
             ]
         )
 
@@ -449,10 +450,6 @@ def draw_dashboard(
                     text = _fmt_pct(value) if is_pct else _fmt_num(value, precision)
                     col.metric(f"{icon} {label}", text, help=tip)
 
-            tim = kpi.get("Time in Market")
-            if tim is not None and not (isinstance(tim, float) and np.isnan(tim)):
-                st.write("Time in Market")
-                st.progress(float(tim) / 100)
         # === Tab 1: Balances & Fees ==============================================
         with perf_tabs[1]:
             bal_cols = st.columns(4)
@@ -544,6 +541,15 @@ def draw_dashboard(
             )
             st.metric("Positions", run_meta.get("Total positions", "—"))
             st.metric("Trades", len(trades_df) if not trades_df.empty else 0)
+
+        # === Tab 5: Time in Market ===========================================
+        with perf_tabs[5]:
+            tim = kpi.get("Time in Market")
+            if tim is not None and not (isinstance(tim, float) and np.isnan(tim)):
+                st.metric("⏱️ Time in Market", _fmt_pct(tim))
+                st.progress(float(tim) / 100)
+            else:
+                st.info("Time-in-market unavailable.")
 
     # ① Price & Trades --------------------------------------------------------
     st.subheader("📉 Price & Trades")

--- a/app/main.py
+++ b/app/main.py
@@ -285,6 +285,14 @@ def draw_dashboard(
         if period_seconds > 0 and not trades_df.empty
         else np.nan
     )
+    avg_trade_h = (
+        (
+            trades_df["exit_time"] - trades_df["entry_time"]
+        ).dt.total_seconds().mean()
+        / 3600
+        if not trades_df.empty
+        else np.nan
+    )
     max_dd_pct = max_dd(equity_df["equity"]) * 100 if not equity_df.empty else np.nan
     pnl_dd_ratio = (
         (total_return * 100) / abs(max_dd_pct)
@@ -317,6 +325,7 @@ def draw_dashboard(
         "Annual Return": annual_return,
         "Profit/DD": pnl_dd_ratio,
         "Time in Market": tim,
+        "Avg Trade (h)": avg_trade_h,
     }
     KPI_ICONS = {
         "PnL ($)": "💰",
@@ -331,6 +340,7 @@ def draw_dashboard(
         "Annual Return": "📅",
         "Profit/DD": "⚡",
         "Time in Market": "⏱️",
+        "Avg Trade (h)": "⏳",
     }
 
     KPI_TOOLTIPS = {
@@ -345,6 +355,7 @@ def draw_dashboard(
         "Sortino": "Downside risk-adjusted return",
         "Profit Factor": "Gross profit divided by gross loss",
         "Win Rate": "Share of profitable trades",
+        "Avg Trade (h)": "Average trade duration in hours",
     }
 
     KPI_PCT_LABELS = {
@@ -428,8 +439,11 @@ def draw_dashboard(
                 "PnL (%)",
                 "Annual Return",
                 "Profit/DD",
+            ]
+            trade_order = [
                 "Win Rate",
                 "Profit Factor",
+                "Avg Trade (h)",
             ]
             risk_order = [
                 "Sharpe",
@@ -439,7 +453,7 @@ def draw_dashboard(
                 "Volatility (252d)",
             ]
 
-            for order in (perf_order, risk_order):
+            for order in (perf_order, trade_order, risk_order):
                 cols = st.columns(len(order))
                 for label, col in zip(order, cols):
                     value = kpi.get(label)

--- a/app/main.py
+++ b/app/main.py
@@ -381,9 +381,11 @@ def draw_dashboard(
                 unsafe_allow_html=True,
             )
 
-    # ╭──────────────────── 📊 OVERVIEW ─────────────────────────────────────╮
+    # ╭──────────────────── 💹 ACCOUNT & Performance ────────────────────────────╮
+
     with st.container(border=True):
-        st.subheader("📊 Overview")
+        st.subheader("💹 Account & Performance")
+
         overview_keys = [
             "PnL ($)",
             "PnL (%)",
@@ -411,11 +413,6 @@ def draw_dashboard(
             precision = 0 if key == "Max DD (days)" else 2
             text = _fmt_pct(val) if is_pct else _fmt_num(val, precision)
             col.metric(f"{icon} {key}", text, help=tip)
-
-    # ╭──────────────────── 💹 ACCOUNT & Performance ────────────────────────────╮
-
-    with st.container(border=True):
-        st.subheader("💹 Account & Performance")
 
         # ------------------------------------------------------------------
         # We analyse the entire back-test by default.

--- a/app/main.py
+++ b/app/main.py
@@ -421,14 +421,16 @@ def draw_dashboard(
             hdr[2].metric("Elapsed", run_meta["Elapsed time"])
             hdr[3].metric("Orders", run_meta["Total orders"])
 
-            kcols = st.columns(len(kpi))
-            for (label, value), col in zip(kpi.items(), kcols):
-                icon = KPI_ICONS.get(label, "")
-                tip = KPI_TOOLTIPS.get(label, "")
-                is_pct = label in KPI_PCT_LABELS
-                precision = 0 if label == "Max DD (days)" else 2
-                text = _fmt_pct(value) if is_pct else _fmt_num(value, precision)
-                col.metric(f"{icon} {label}", text, help=tip)
+            items = list(kpi.items())
+            for i in range(0, len(items), 4):
+                row = st.columns(4)
+                for (label, value), col in zip(items[i : i + 4], row):
+                    icon = KPI_ICONS.get(label, "")
+                    tip = KPI_TOOLTIPS.get(label, "")
+                    is_pct = label in KPI_PCT_LABELS
+                    precision = 0 if label == "Max DD (days)" else 2
+                    text = _fmt_pct(value) if is_pct else _fmt_num(value, precision)
+                    col.metric(f"{icon} {label}", text, help=tip)
 
         # === Tab 1: Balances & Fees ==============================================
         with perf_tabs[1]:

--- a/app/main.py
+++ b/app/main.py
@@ -386,33 +386,6 @@ def draw_dashboard(
     with st.container(border=True):
         st.subheader("💹 Account & Performance")
 
-        overview_keys = [
-            "PnL ($)",
-            "PnL (%)",
-            "Annual Return",
-            "Max DD (%)",
-            "Max DD (days)",
-            "Win Rate",
-            "Sharpe",
-            "Sortino",
-            "Profit Factor",
-        ]
-        ocols = st.columns(len(overview_keys))
-        pct_labels = {
-            "PnL (%)",
-            "Win Rate",
-            "Max DD (%)",
-            "Annual Return",
-            "Time in Market",
-        }
-        for key, col in zip(overview_keys, ocols):
-            val = kpi.get(key)
-            icon = KPI_ICONS.get(key, "")
-            tip = KPI_TOOLTIPS.get(key, "")
-            is_pct = key in pct_labels
-            precision = 0 if key == "Max DD (days)" else 2
-            text = _fmt_pct(val) if is_pct else _fmt_num(val, precision)
-            col.metric(f"{icon} {key}", text, help=tip)
 
         # ------------------------------------------------------------------
         # We analyse the entire back-test by default.
@@ -439,6 +412,34 @@ def draw_dashboard(
             hdr[1].metric("Finished", _fmt_dt(run_meta["Run finished"]))
             hdr[2].metric("Elapsed", run_meta["Elapsed time"])
             hdr[3].metric("Orders", run_meta["Total orders"])
+
+            overview_keys = [
+                "PnL ($)",
+                "PnL (%)",
+                "Annual Return",
+                "Max DD (%)",
+                "Max DD (days)",
+                "Win Rate",
+                "Sharpe",
+                "Sortino",
+                "Profit Factor",
+            ]
+            ocols = st.columns(len(overview_keys))
+            pct_labels = {
+                "PnL (%)",
+                "Win Rate",
+                "Max DD (%)",
+                "Annual Return",
+                "Time in Market",
+            }
+            for key, col in zip(overview_keys, ocols):
+                val = kpi.get(key)
+                icon = KPI_ICONS.get(key, "")
+                tip = KPI_TOOLTIPS.get(key, "")
+                is_pct = key in pct_labels
+                precision = 0 if key == "Max DD (days)" else 2
+                text = _fmt_pct(val) if is_pct else _fmt_num(val, precision)
+                col.metric(f"{icon} {key}", text, help=tip)
 
             # KPI grid
             kcols = st.columns(len(kpi))

--- a/app/main.py
+++ b/app/main.py
@@ -421,10 +421,27 @@ def draw_dashboard(
             hdr[2].metric("Elapsed", run_meta["Elapsed time"])
             hdr[3].metric("Orders", run_meta["Total orders"])
 
-            items = list(kpi.items())
-            for i in range(0, len(items), 4):
-                row = st.columns(4)
-                for (label, value), col in zip(items[i : i + 4], row):
+
+            perf_order = [
+                "PnL ($)",
+                "PnL (%)",
+                "Annual Return",
+                "Profit/DD",
+                "Win Rate",
+                "Profit Factor",
+            ]
+            risk_order = [
+                "Sharpe",
+                "Sortino",
+                "Max DD (%)",
+                "Max DD (days)",
+                "Volatility (252d)",
+            ]
+
+            for order in (perf_order, risk_order):
+                cols = st.columns(len(order))
+                for label, col in zip(order, cols):
+                    value = kpi.get(label)
                     icon = KPI_ICONS.get(label, "")
                     tip = KPI_TOOLTIPS.get(label, "")
                     is_pct = label in KPI_PCT_LABELS
@@ -432,6 +449,10 @@ def draw_dashboard(
                     text = _fmt_pct(value) if is_pct else _fmt_num(value, precision)
                     col.metric(f"{icon} {label}", text, help=tip)
 
+            tim = kpi.get("Time in Market")
+            if tim is not None and not (isinstance(tim, float) and np.isnan(tim)):
+                st.write("Time in Market")
+                st.progress(float(tim))
         # === Tab 1: Balances & Fees ==============================================
         with perf_tabs[1]:
             bal_cols = st.columns(4)


### PR DESCRIPTION
## Summary
- compute drawdown duration and add KPI tooltips
- show key metrics in new Overview section
- display equity and drawdown charts side by side with fees in an expander
- collapse advanced risk charts and trade list in expanders

## Testing
- `python -m py_compile app/main.py`
- `python -m py_compile modules/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867ff0c4d4c832b9043d126dcaec81c