### PR TITLE
Fix missing Price & Trades chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ NautilusTrader is a rapidly evolving open-source platform for algorithmic tradin
 ---
 
 ## 🛠️ Quick Start
-Run the app:
+Install dependencies and run the app:
 
 ```bash
+pip install -r requirements.txt
 streamlit run app/main.py
 ```
+
+The requirements include `streamlit-lightweight-charts-v5`. If it isn't
+available, the dashboard will display Plotly charts instead.
 
 ## 📈 Equity & Drawdown
 

--- a/app/main.py
+++ b/app/main.py
@@ -33,6 +33,7 @@ from modules.backtest_runner import run_backtest
 from modules.dashboard_actor import DashboardPublisher  # optional, only if supported
 from modules.data_connector import DataConnector
 from modules.csv_data import load_ohlcv_csv
+DATA_DIR = pathlib.Path(__file__).resolve().parents[1]
 from datetime import timedelta
 
 # ───────────────────────────── Streamlit page ────────────────────────────────
@@ -1461,7 +1462,7 @@ with st.sidebar:
     if info.doc:
         st.caption(info.doc)
 
-    connector = DataConnector()
+    connector = DataConnector(csv_dir=DATA_DIR)
 
     # ── Data source tabs ────────────────────────────────────────────────
     st.markdown(
@@ -1596,7 +1597,7 @@ with st.sidebar:
         start_dt = datetime.combine(start_ch, datetime.min.time())
         end_dt = datetime.combine(end_ch, datetime.min.time())
     with st.spinner("Running back‑test… please wait"):
-        connector = DataConnector()
+        connector = DataConnector(csv_dir=DATA_DIR)
         data_df = connector.load(data_source, data_spec, start=start_dt, end=end_dt)
 
         if data_df.empty:

--- a/app/main.py
+++ b/app/main.py
@@ -23,8 +23,11 @@ import plotly.graph_objects as go
 import streamlit as st
 try:
     from lightweight_charts_v5 import lightweight_charts_v5_component as lwc
-except ImportError:
-    lwc = None
+except Exception:
+    try:  # older package name
+        from streamlit_lightweight_charts import renderLightweightCharts as lwc
+    except Exception:  # component unavailable
+        lwc = None
 
 # ────────────────────────────── local code ───────────────────────────────────
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -1079,7 +1082,117 @@ def draw_dashboard(
             },
         }]
 
-        lwc(name="price_chart", charts=charts, height=600 if has_volume else 420)
+        try:
+            lwc(name="price_chart", charts=charts, height=600 if has_volume else 420)
+        except Exception:
+            st.warning("Failed to render lightweight chart. Using Plotly fallback.")
+            fig = go.Figure()
+            if price_style == "Candlesticks" and {"open", "high", "low", "close"}.issubset(price_df.columns):
+                fig.add_trace(
+                    go.Candlestick(
+                        x=price_df.index,
+                        open=price_df["open"],
+                        high=price_df["high"],
+                        low=price_df["low"],
+                        close=price_df["close"],
+                        name="Price",
+                    )
+                )
+            else:
+                fig.add_trace(
+                    go.Scatter(
+                        x=price_series.index,
+                        y=price_series.values,
+                        mode="lines",
+                        name="Price",
+                    )
+                )
+
+            if show_sma:
+                sma = price_series.rolling(50).mean()
+                fig.add_trace(
+                    go.Scatter(
+                        x=sma.index,
+                        y=sma.values,
+                        mode="lines",
+                        line=dict(color="#6366f1"),
+                        name="50 SMA",
+                    )
+                )
+
+            if show_ema:
+                ema = price_series.ewm(span=21, adjust=False).mean()
+                fig.add_trace(
+                    go.Scatter(
+                        x=ema.index,
+                        y=ema.values,
+                        mode="lines",
+                        line=dict(color="#fbbf24"),
+                        name="21 EMA",
+                    )
+                )
+
+            if not trades_df.empty:
+                buys = trades_df[trades_df.get("entry_side", "").str.upper() == "LONG"]
+                sells = trades_df[trades_df.get("entry_side", "").str.upper() == "SELL"]
+
+                if show_long and not buys.empty:
+                    fig.add_trace(
+                        go.Scatter(
+                            x=buys["entry_time"],
+                            y=buys["entry_price"],
+                            mode="markers",
+                            marker_symbol="triangle-up",
+                            marker_color=ACCENT,
+                            name="Buy",
+                        )
+                    )
+
+                if show_short and not sells.empty:
+                    fig.add_trace(
+                        go.Scatter(
+                            x=sells["entry_time"],
+                            y=sells["entry_price"],
+                            mode="markers",
+                            marker_symbol="triangle-down",
+                            marker_color=NEG,
+                            name="Sell",
+                        )
+                    )
+
+                if show_exit and {"exit_time", "profit"}.issubset(trades_df.columns):
+                    fig.add_trace(
+                        go.Scatter(
+                            x=trades_df["exit_time"],
+                            y=trades_df["exit_price"],
+                            mode="markers",
+                            marker_symbol="circle",
+                            marker_color="#6b7280",
+                            name="Exit",
+                        )
+                    )
+
+            if has_volume:
+                fig.add_trace(
+                    go.Bar(
+                        x=price_df.index,
+                        y=price_df["volume"],
+                        name="Volume",
+                        marker_color="#d1d5db",
+                        yaxis="y2",
+                    )
+                )
+                fig.update_layout(
+                    yaxis2=dict(
+                        overlaying="y",
+                        side="right",
+                        showgrid=False,
+                        title="Volume",
+                    )
+                )
+
+            fig.update_layout(template=TPL, height=600 if has_volume else 420)
+            st.plotly_chart(fig, use_container_width=True)
 
     st.markdown("---")
 

--- a/modules/backtest_runner.py
+++ b/modules/backtest_runner.py
@@ -138,8 +138,9 @@ def load_bars(csv_path: str):
 
     ts = df["timestamp"]
     if pd.api.types.is_numeric_dtype(ts):
-        ts_int = pd.to_numeric(ts, errors="coerce").astype("Int64")
-        digits = ts_int.dropna().astype(str).str.len().mode()[0]
+        ts_num = pd.to_numeric(ts, errors="coerce")
+        ts_int = ts_num.fillna(0).astype("Int64")
+        digits = ts_int.dropna().abs().astype(str).str.len().mode()[0]
         if digits >= 18:
             unit = "ns"
         elif digits >= 16:

--- a/modules/csv_data.py
+++ b/modules/csv_data.py
@@ -85,8 +85,9 @@ def load_ohlcv_csv(csv_path: str) -> pd.DataFrame:
     # ── timestamp → datetime UTC
     ts = df["timestamp"]
     if pd.api.types.is_numeric_dtype(ts):
-        ts_int = pd.to_numeric(ts, errors="coerce").astype("Int64")
-        digits = ts_int.dropna().astype(str).str.len().mode()[0]
+        ts_num = pd.to_numeric(ts, errors="coerce")
+        ts_int = ts_num.fillna(0).astype("Int64")
+        digits = ts_int.dropna().abs().astype(str).str.len().mode()[0]
         if digits >= 18:
             unit = "ns"
         elif digits >= 16:


### PR DESCRIPTION
## Summary
- add Plotly fallback when `streamlit-lightweight-charts-v5` is not installed

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6869716a595c832b8da2074f2c5baf35