### PR TITLE
Adjust chart to show full timeframe

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -963,16 +963,22 @@ def draw_dashboard(
             "to": price_df.index[-1].strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
 
+        time_scale_opts = {
+            "minBarSpacing": 0.001,  # allow strong compression
+            "rightOffset": 0,
+            "fixLeftEdge": True,
+            "fixRightEdge": True,
+            "fitContent": True,
+            "visibleRange": visible_range,
+        }
+
         charts = [{
             "series": series,
             "height": 600 if has_volume else 420,
             "chart": {
                 "layout": {"textColor": "#000" if TPL == "plotly_white" else "#fff"},
                 "watermark": {"visible": False},
-                "timeScale": {
-                    "fitContent": True,
-                    "visibleRange": visible_range,
-                },
+                "timeScale": time_scale_opts,
             },
         }]
 

--- a/app/main.py
+++ b/app/main.py
@@ -958,13 +958,21 @@ def draw_dashboard(
                 "options": {"color": "#d1d5db"},
             })
 
+        visible_range = {
+            "from": int(price_df.index[0].timestamp()),
+            "to": int(price_df.index[-1].timestamp()),
+        }
+
         charts = [{
             "series": series,
             "height": 600 if has_volume else 420,
             "chart": {
                 "layout": {"textColor": "#000" if TPL == "plotly_white" else "#fff"},
                 "watermark": {"visible": False},
-                "timeScale": {"fitContent": True},
+                "timeScale": {
+                    "fitContent": True,
+                    "visibleRange": visible_range,
+                },
             },
         }]
 

--- a/app/main.py
+++ b/app/main.py
@@ -964,6 +964,7 @@ def draw_dashboard(
             "chart": {
                 "layout": {"textColor": "#000" if TPL == "plotly_white" else "#fff"},
                 "watermark": {"visible": False},
+                "timeScale": {"fitContent": True},
             },
         }]
 

--- a/app/main.py
+++ b/app/main.py
@@ -959,8 +959,8 @@ def draw_dashboard(
             })
 
         visible_range = {
-            "from": int(price_df.index[0].timestamp()),
-            "to": int(price_df.index[-1].timestamp()),
+            "from": price_df.index[0].strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "to": price_df.index[-1].strftime("%Y-%m-%dT%H:%M:%SZ"),
         }
 
         charts = [{


### PR DESCRIPTION
## Summary
- ensure `lightweight_charts_v5` charts fit all available data on load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686babe71444832badb582b20ea1d789