### PR TITLE
Fix env loading for ClickHouse

### DIFF
--- a/modules/clickhouse.py
+++ b/modules/clickhouse.py
@@ -20,12 +20,16 @@ from __future__ import annotations
 import os
 import re
 import sys
+
+from dotenv import load_dotenv
 from datetime import datetime, timezone, timedelta
 from types import ModuleType
 from typing import Dict, Optional, Tuple
 
 import pandas as pd
 from clickhouse_driver import Client
+
+load_dotenv()
 
 # ── Nautilus Trader ─────────────────────────────────────────────── #
 from nautilus_trader.model import InstrumentId, Symbol, Venue

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ numpy
 plotly
 nautilus_trader
 clickhouse-driver
+python-dotenv
 streamlit-lightweight-charts-v5>=0.1.7
 extra-streamlit-components


### PR DESCRIPTION
## Summary
- load environment variables for ClickHouse connector
- add python-dotenv dependency

## Testing
- `python -m py_compile modules/clickhouse.py modules/data_connector.py app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686d8f1330ec832b9a1387082aeacab1